### PR TITLE
Change telosbookdex market indexing mechanisms

### DIFF
--- a/contracts/telosbookdex/telosbookdex.cpp
+++ b/contracts/telosbookdex/telosbookdex.cpp
@@ -7,7 +7,7 @@
 #define DEPOSITS_ACTIONS (withdraw)(swapdeposit)(deps2earn)
 #define GLOBAL_ACTIONS (init)(maintenance)(reward)
 #define HANDLERS (htransfer)(hbroadcast)
-#define DEBUG_ACTIONS (hotfix)(testdao)(timeoffset)
+#define DEBUG_ACTIONS (testdao)(timeoffset)
 
 
 EOSIO_DISPATCH_DEX (

--- a/contracts/telosbookdex/telosbookdex.hpp
+++ b/contracts/telosbookdex/telosbookdex.hpp
@@ -309,11 +309,6 @@ namespace vapaee {
                     hbroadcast(ballot_name, final_results, total_voters);
                 };
 
-                ACTION hotfix (int max, name scope, asset q) {
-                    PRINT("\nACTION telosbookdex.hotfix() ------------------\n");
-                    vapaee::dex::exchange::action_hotfix(max, scope, q);
-                };
-
                 ACTION timeoffset (uint32_t offset) {
                     PRINT("\nACTION telosbookdex.timeoffset() ------------------\n");
                     vapaee::dex::global::action_set_time_offset(offset);

--- a/contracts/testcontract/testcontract.hpp
+++ b/contracts/testcontract/testcontract.hpp
@@ -2,12 +2,13 @@
 #include <vapaee/base/base.hpp>
 #include <vapaee/tprofile/tables.all.hpp>
 
-using namespace eosio;
-using namespace std;
+
+using vapaee::utils::symbols_get_index;
+using vapaee::utils::hash;
 
 namespace testing {
 
-    static name contract_name = eosio::name("testcontract");
+    static name contract_name = "testcontract"_n;
 
     CONTRACT testcontract : public eosio::contract {
         public:
@@ -17,7 +18,7 @@ namespace testing {
                 profiles prof_table(tprofile::contract, tprofile::contract.value);
 
                 auto alias_index = prof_table.get_index<"alias"_n>();
-                auto profile_iter = alias_index.find(vapaee::utils::hash(alias));
+                auto profile_iter = alias_index.find(hash(alias));
                 check(profile_iter != alias_index.end(), "profile not found");
 
                 access grant_table(tprofile::contract, profile_iter->id);
@@ -39,6 +40,18 @@ namespace testing {
 
             ACTION multiplytest(asset A, asset B) {
                 print(multiply(A, B));
+            }
+
+            ACTION getindex(symbol_code A, symbol_code B) {
+                print(symbols_get_index(A, B));
+            }
+
+            ACTION rawname(name n) {
+                print(n.value);
+            }
+
+            ACTION rawsymcode(symbol_code scode) {
+                print(scode.raw());
             }
     };
 

--- a/include/vapaee/base/utils.hpp
+++ b/include/vapaee/base/utils.hpp
@@ -239,9 +239,7 @@ namespace vapaee {
         }
 
         uint128_t symbols_get_index(symbol_code A, symbol_code B) {
-            name a_name(to_lowercase(A.to_string()));
-            name b_name(to_lowercase(B.to_string()));
-            return ((uint128_t)a_name.value << 64) | a_name.value;
+            return ((uint128_t)A.raw() << 64) | (uint128_t)B.raw();
         }
     }; // namespace utils
 }; // namespace vaapee

--- a/include/vapaee/dex/modules/dao.hpp
+++ b/include/vapaee/dex/modules/dao.hpp
@@ -664,18 +664,17 @@ namespace vapaee {
                     ptr != currency_index.end();
                     ptr = currency_index.lower_bound(sym_code.raw())
                 ) {
-                    PRINT("  for (currency_index) ",ptr->table.to_string(),", ", ptr->currency.to_string(), " \n");
+                    PRINT("  for (currency_index) ", ptr->repr(), ", ", ptr->currency.to_string(), " \n");
                     if (sym_code == ptr->currency) {
 
                         // add this market to be slowly deleted (history and orders)
-                        PRINT("  -> delmarkets.emplace(",ptr->table.to_string(),")\n");
+                        PRINT("  -> delmarkets.emplace(", ptr->repr(), ")\n");
                         deltable.emplace(contract, [&](auto &a){
                             a.id = ptr->id;
-                            a.table = ptr->table;
                         });
 
                         // we delete de actual market
-                        PRINT("  -> markets.erase(",ptr->table.to_string(),")\n");
+                        PRINT("  -> markets.erase(", ptr->repr(), ")\n");
                         table.erase(*ptr);
 
                         // delete ordersummary unique entrance for this market
@@ -699,18 +698,17 @@ namespace vapaee {
                     ptr != commodity_index.end();
                     ptr = commodity_index.lower_bound(sym_code.raw())
                 ) {
-                    PRINT("  for (commodity_index) ",ptr->table.to_string(),", ", ptr->commodity.to_string(), " \n");
+                    PRINT("  for (commodity_index) ", ptr->repr(), ", ", ptr->commodity.to_string(), " \n");
                     if (sym_code == ptr->commodity) {
 
                         // add this market to be slowly deleted (history and orders)
-                        PRINT("  -> delmarkets.emplace(",ptr->table.to_string(),")\n");
+                        PRINT("  -> delmarkets.emplace(", ptr->repr(), ")\n");
                         deltable.emplace(contract, [&](auto &a){
                             a.id = ptr->id;
-                            a.table = ptr->table;
                         });
 
                         // we delete de actual market
-                        PRINT("  -> markets.erase(",ptr->table.to_string(),")\n");
+                        PRINT("  -> markets.erase(", ptr->repr(),")\n");
                         table.erase(*ptr);
 
                         // delete ordersummary unique entrance for this market

--- a/include/vapaee/dex/modules/deposit.hpp
+++ b/include/vapaee/dex/modules/deposit.hpp
@@ -336,35 +336,37 @@ namespace vapaee {
                 PRINT(" -> trigger_event: ", std::to_string(trigger_event), "\n");
 
                 // if is not an internal inline action then the user "from" must have beed signed this transaction
-                if ( !has_auth( contract )) {
-                    require_auth( from );
+                if (!has_auth(contract)) {
+                    require_auth(from);
                 }
                 
-                check( is_account( to ), "to account does not exist");
+                check(is_account(to), "to account does not exist");
                 auto sym = quantity.symbol.code();
                 if (!aux_is_token_blacklisted(sym)) {
                     tokens tokenstable(contract, contract.value);
                     const auto& st = tokenstable.get( sym.raw() );
                 }
 
-                require_recipient( from );
+                require_recipient(from);
 
                 if (from != to)
-                    require_recipient( to );
+                    require_recipient(to);
 
-                check( quantity.is_valid(), "invalid quantity" );
-                check( quantity.amount > 0, "must transfer positive quantity" );
+                check(quantity.is_valid(), "invalid quantity");
+                check(quantity.amount > 0, "must transfer positive quantity");
                 //check( quantity.symbol.precision() == internal_precision, "symbol precision mismatch" );
-                check( memo.size() <= 256, "memo has more than 256 bytes" );
+                check(memo.size() <= 256, "memo has more than 256 bytes");
                 
                 name ram_payer;
-                if ( has_auth( to ) ) {
+                if (has_auth(to))
                     ram_payer = to;
-                } else if (has_auth( from )) {
+
+                else if (has_auth(from))
                     ram_payer = from;
-                } else {
+
+                else
                     ram_payer = contract;
-                }
+                
                 PRINT("   -> ram_payer: ", ram_payer.to_string(), "\n");
                 aux_substract_deposits(from, quantity);
                 aux_add_deposits(to, quantity, ram_payer);

--- a/include/vapaee/dex/modules/exchange.hpp
+++ b/include/vapaee/dex/modules/exchange.hpp
@@ -519,23 +519,27 @@ namespace vapaee {
                         // auto-withraw -----------
                         asset maker_gains_real = aux_get_real_asset(maker_gains);
                         PRINT("  --> withdraw: transfer ", maker_gains_real.to_string(), " to ", maker.to_string(), "\n");
-                        action(
-                            permission_level{contract,name("active")},
-                            contract,
-                            name("withdraw"),
-                            std::make_tuple(maker, maker_gains_real,  maker_client)
-                        ).send();
-                        aux_trigger_event(maker_gains_real.symbol.code(), name("withdraw"), maker, contract, maker_gains_real, _asset, _asset);
+                        if (maker_gains_real.amount > 0) {
+                            action(
+                                permission_level{contract,name("active")},
+                                contract,
+                                name("withdraw"),
+                                std::make_tuple(maker, maker_gains_real,  maker_client)
+                            ).send();
+                            aux_trigger_event(maker_gains_real.symbol.code(), name("withdraw"), maker, contract, maker_gains_real, _asset, _asset);
+                        }
                         
                         asset taker_gains_real = aux_get_real_asset(taker_gains);
                         PRINT("  --> withdraw: transfer ", taker_gains_real.to_string(), " to ", maker.to_string(), "\n");
-                        action(
-                            permission_level{contract,name("active")},
-                            contract,
-                            name("withdraw"),
-                            std::make_tuple(taker, taker_gains_real, taker_client)
-                        ).send();
-                        aux_trigger_event(taker_gains_real.symbol.code(), name("withdraw"), taker, contract, taker_gains_real, _asset, _asset);    
+                        if (taker_gains_real.amount > 0) {
+                            action(
+                                permission_level{contract,name("active")},
+                                contract,
+                                name("withdraw"),
+                                std::make_tuple(taker, taker_gains_real, taker_client)
+                            ).send();
+                            aux_trigger_event(taker_gains_real.symbol.code(), name("withdraw"), taker, contract, taker_gains_real, _asset, _asset);    
+                        }
 
 
                         // experience ------

--- a/include/vapaee/dex/modules/exchange.hpp
+++ b/include/vapaee/dex/modules/exchange.hpp
@@ -43,14 +43,16 @@ namespace vapaee {
 
                 sellorders selltable(contract, market);
                 asset return_amount;
-                name table = aux_get_table_from_market(market);
                 
                 ordersummary o_summary(contract, contract.value);
                 auto orders_ptr = o_summary.find(can_market);
                 bool reverse_scope = can_market != market;
 
                 // Register event
-                aux_register_event(owner, name("cancel.order"), table.to_string() + "|" + std::to_string(orders.size()));
+                aux_register_event(
+                    owner,
+                    name("cancel.order"),
+                    aux_get_market_repr(market) +  "|" + std::to_string(orders.size()));
 
                 for (int i=0; i<orders.size(); i++) {
                     uint64_t order_id = orders[i];
@@ -629,8 +631,8 @@ namespace vapaee {
                     auto user_itr = userorders_table.find(market_sell);
                     if (user_itr == userorders_table.end()) {
                         PRINT("   userorders_table.emplace id:", std::to_string((unsigned long)market_sell),"\n"); 
-                        userorders_table.emplace( ram_payer, [&]( auto& a ) {
-                            a.table = aux_get_table_from_market(market_sell).to_string();
+                        userorders_table.emplace(ram_payer, [&](auto& a) {
+                            a.table = aux_get_market_repr(market_sell);
                             a.market = market_sell;
                             a.ids.push_back(id);
                         });
@@ -694,7 +696,6 @@ namespace vapaee {
                 // Check client is valid and registered
                 vapaee::dex::client::aux_assert_client_is_valid(client);
 
-
                 if (type == name("sell")) {
                     aux_generate_sell_order(false, owner, market_sell, market_buy, total, payment, price, inverse, ram_payer, client);
                 } else if (type == name("buy")) {
@@ -718,10 +719,6 @@ namespace vapaee {
                 aux_generate_order(owner, type, total, price, owner, client);
 
                 PRINT("vapaee::dex::exchange::action_order() ...\n");      
-            }
-
-            void action_hotfix(int num, name account, asset quantity) {
-                
             }
             
         };     

--- a/include/vapaee/dex/modules/maintenance.hpp
+++ b/include/vapaee/dex/modules/maintenance.hpp
@@ -31,7 +31,6 @@ namespace vapaee {
 
                 sellorders selltable(contract, market);
                 asset return_amount;
-                name table = aux_get_table_from_market(market);
                 
                 uint64_t order_id = id;
                 auto itr = selltable.find(order_id);

--- a/include/vapaee/dex/modules/record.hpp
+++ b/include/vapaee/dex/modules/record.hpp
@@ -146,13 +146,11 @@ namespace vapaee {
                 
                 symbol_code A = amount.symbol.code();
                 symbol_code B = payment.symbol.code();
-                name scope = aux_get_canonical_scope_for_symbols(A, B);
+                uint128_t index = aux_get_canonical_index_for_symbols(A, B);
 
                 
                 bool is_buy = false;
-                PRINT(" -> scope: ", scope.to_string(), "\n");
-
-                if (scope == aux_get_scope_for_tokens(B, A)) {
+                if (index == symbols_get_index(B, A)) {
                     // swap buyer / seller names
                     tmp_name = buyer;
                     buyer = seller;
@@ -217,13 +215,31 @@ namespace vapaee {
 
                 // register event for activity log
                 if (!inverted) {
-                    aux_register_event(owner, name("transaction"), scope.to_string() + "|" + buyer.to_string() + "|" + seller.to_string() + "|" + amount.to_string() + "|" + payment.to_string() + "|" + price.to_string() );
+                    aux_register_event(
+                        owner,
+                        "transaction"_n,
+                        aux_get_market_repr(market) + "|" +
+                        buyer.to_string() + "|" + 
+                        seller.to_string() + "|" +
+                        amount.to_string() + "|" +
+                        payment.to_string() + "|" +
+                        price.to_string()
+                    );
                 } else {
-                    name actual_scope = aux_get_scope_for_tokens(A, B);
-                    if (scope == actual_scope) {
-                        actual_scope = aux_get_scope_for_tokens(B, A);
-                    }
-                    aux_register_event(owner, name("transaction"), actual_scope.to_string() + "|" + buyer.to_string() + "|" + seller.to_string() + "|" + payment.to_string() + "|" + amount.to_string() + "|" + inverse.to_string() );
+                    uint128_t actual_index = symbols_get_index(A, B);
+                    if (index == actual_index)
+                        actual_index = symbols_get_index(B, A);
+        
+                    aux_register_event(
+                        owner,
+                        "transaction"_n,
+                        aux_get_market_repr(market) + "|" +
+                        buyer.to_string() + "|" +
+                        seller.to_string() + "|" +
+                        payment.to_string() + "|" +
+                        amount.to_string() + "|" +
+                        inverse.to_string()
+                    );
                 }
                 
                 // aux_trigger_event(amount.symbol.code(),  name("deal"), seller, buyer,  amount,  payment, price);
@@ -329,9 +345,9 @@ namespace vapaee {
                 // save table l24table (price & volume/h)
                 historyblock blocktable(contract, can_market);
                 uint64_t bh_id = blocktable.available_primary_key();
-                auto index = blocktable.template get_index<name("hour")>();
-                auto bptr = index.find(hour);
-                if (bptr == index.end()) {
+                auto hour_index = blocktable.get_index<"hour"_n>();
+                auto bptr = hour_index.find(hour);
+                if (bptr == hour_index.end()) {
                     blocktable.emplace(contract, [&](auto & a) {
                         a.id = bh_id;
                         a.price = price;
@@ -363,7 +379,13 @@ namespace vapaee {
                 ordersummary summary(contract, contract.value);
                 auto orders_itr = summary.find(can_market);
 
-                check(orders_itr != summary.end(), (string("Why is this entry missing? ") + scope.to_string() + string(" canonical market: ") + std::to_string((unsigned long)can_market)).c_str());
+                check(
+                    orders_itr != summary.end(),
+                    (string("Why is this entry missing? ") + 
+                     aux_get_market_repr(market) +
+                     string(" canonical market: ") +
+                     aux_get_market-repr(can_market))
+                );
                 summary.modify(*orders_itr, same_payer, [&](auto & a){
                     a.deals = h_id+1;
                     a.blocks = bh_id+1;

--- a/include/vapaee/dex/modules/record.hpp
+++ b/include/vapaee/dex/modules/record.hpp
@@ -384,7 +384,7 @@ namespace vapaee {
                     (string("Why is this entry missing? ") + 
                      aux_get_market_repr(market) +
                      string(" canonical market: ") +
-                     aux_get_market-repr(can_market))
+                     aux_get_market_repr(can_market))
                 );
                 summary.modify(*orders_itr, same_payer, [&](auto & a){
                     a.deals = h_id+1;

--- a/include/vapaee/dex/modules/utils.hpp
+++ b/include/vapaee/dex/modules/utils.hpp
@@ -27,18 +27,6 @@ namespace vapaee {
                 return (has_auth(owner)) ? owner : same_payer; 
             }
 
-            name aux_get_scope_for_tokens(const symbol_code & a, const symbol_code & b) {
-                string a_sym_str = a.to_string();
-                string b_sym_str = b.to_string();
-                string scope_str = a_sym_str + "." + b_sym_str;
-                scope_str = to_lowercase(scope_str);
-                if (scope_str.size() > 12) {
-                    scope_str = scope_str.substr(0,12);
-                }
-                name scope(scope_str);
-                return scope;
-            }
-
             /*
              *  auxiliary extend asset
              *
@@ -47,24 +35,6 @@ namespace vapaee {
              *
              */
             asset aux_extend_asset(const asset & quantity) {
-                // PRINT("vapaee::dex::utils::aux_extend_asset()\n");
-                // asset extended = quantity;
-                // uint64_t amount = quantity.amount;
-                // uint8_t precision = quantity.symbol.precision();
-                // symbol_code sym_code = quantity.symbol.code();
-                // 
-                // // no extension
-                // if (vapaee::dex::internal_precision == precision) return quantity;
-
-                // // extension
-                // uint8_t extension = vapaee::dex::internal_precision - precision;
-                // uint64_t multiplier = pow(10, extension);
-                // amount = amount * multiplier;
-
-                // extended.amount = amount;
-                // extended.symbol = symbol(sym_code, vapaee::dex::internal_precision);
-                // PRINT("vapaee::dex::utils::aux_extend_asset() ...\n");
-                // return extended;
                 return asset_change_precision(
                     quantity, vapaee::dex::internal_precision);
             }

--- a/include/vapaee/dex/tables/delmarkets.hpp
+++ b/include/vapaee/dex/tables/delmarkets.hpp
@@ -1,15 +1,16 @@
 #include "./_aux.hpp"
 
-        // TABLE delmarkets -----------
-        // scope: contract
-        // list of the markets marked to delete (slowly cancel orders and delete history)
-        TABLE delmarkets_table {
-            uint64_t id;            // id del market
-            name table;             // xxx.yyy
-            uint64_t primary_key() const { return id; }
-            uint64_t by_table_key() const { return table.value; }
-        };
-        typedef eosio::multi_index< "delmarkets"_n, delmarkets_table,
-            indexed_by<"table"_n, const_mem_fun<delmarkets_table, uint64_t, &delmarkets_table::by_table_key>>
-        > delmarkets;
-        // ------------------------------------
+
+// scope: contract
+// list of the markets marked to delete
+// (slowly cancel orders and delete history)
+TABLE delmarkets_table {
+    uint64_t id;            // market id
+//    name table;             // xxx.yyy
+    uint64_t primary_key() const { return id; }
+//    uint64_t by_table_key() const { return table.value; }
+};
+
+typedef eosio::multi_index<"delmarkets"_n, delmarkets_table
+//    indexed_by<"table"_n, const_mem_fun<delmarkets_table, uint64_t, &delmarkets_table::by_table_key>>
+> delmarkets;

--- a/include/vapaee/dex/tables/markets.hpp
+++ b/include/vapaee/dex/tables/markets.hpp
@@ -1,24 +1,29 @@
 #include "./_aux.hpp"
 
-        
-        // ------------------------------------
-        // TABLE markets
-        // scope: contract
-        TABLE markets_table {
-            uint64_t id;
-            name table;     // xxx.zzz (do not asume it is unique)
-            symbol_code commodity;
-            symbol_code currency;
-            uint64_t primary_key() const { return id; }
-            uint64_t by_table_key() const { return table.value; }
-            uint64_t by_commodity_key() const { return commodity.raw(); }
-            uint64_t by_currency_key() const { return currency.raw(); }
-        };
+#include <vapaee/base/utils.hpp>
 
-        typedef eosio::multi_index< "markets"_n, markets_table,
-            indexed_by<"table"_n, const_mem_fun<markets_table, uint64_t, &markets_table::by_table_key>>,
-            indexed_by<"commodity"_n, const_mem_fun<markets_table, uint64_t, &markets_table::by_commodity_key>>,
-            indexed_by<"currency"_n, const_mem_fun<markets_table, uint64_t, &markets_table::by_currency_key>>
-        > markets;
-        // ------------------------------------
+
+// scope: contract
+TABLE markets_table {
+    uint64_t id;
+    symbol_code commodity;
+    symbol_code currency;
+    uint64_t primary_key() const { return id; }
+    uint64_t by_commodity_key() const { return commodity.raw(); }
+    uint64_t by_currency_key() const { return currency.raw(); }
+
+    uint128_t by_tokens_index() const {
+        return vapaee::utils::symbols_get_index(commodity, currency);
+    }
+
+    string repr() const {
+        return commodity.to_string() + "/" + currency.to_string();
+    }
+};
+
+typedef eosio::multi_index<"markets"_n, markets_table,
+    indexed_by<"commodity"_n, const_mem_fun<markets_table, uint64_t, &markets_table::by_commodity_key>>,
+    indexed_by<"currency"_n, const_mem_fun<markets_table, uint64_t, &markets_table::by_currency_key>>,
+    indexed_by<"tokensidx"_n, const_mem_fun<markets_table, uint128_t, &markets_table::by_tokens_index>>
+> markets;
         

--- a/include/vapaee/dex/tables/tokens.hpp
+++ b/include/vapaee/dex/tables/tokens.hpp
@@ -1,67 +1,31 @@
 #include "./_aux.hpp"
 
-        
-        // ------------------------------------
-        /*
-        struct contact_struc {
-            string project;
-            string admin;
-        }
-        struct image_struc {
-            string icon;
-            string iconlg;
-            string banner;
-        }
-        struct info_struc {
-            string title;
-            string website;
-            string brief;
-        }
-        // scope: contract
-        TABLE reg_token_table {
-            symbol_code symbol;
-            vector<uint64_t> groups;       // this token may belong to a group of tokens
-            uint8_t precision;
-            name contract;
-            name admin;
-            info_struc info;
-            image_struc image;
-            contact_struc contact;
-            time_point_sec date;
-            // name ballot; ????
-            uint32_t data;
-            bool tradeable;
-            bool currency;
-            uint64_t primary_key() const { return symbol.raw(); }
-            uint64_t by_contract_key() const { return contract.value; }
-        };        
-        */
 
-        // TABLE tokens (registered currency) -----------
-        // scope: contract
-        TABLE reg_token_table {
-            symbol_code symbol;
-            vector<uint64_t> groups;       // this token may belong to a group of tokens
-            uint8_t precision;
-            name contract;
-            name admin;
-            string title;
-            string website;
-            string brief;
-            string banner;
-            string icon;
-            string iconlg;
-            string pcontact;
-            string gcontact;
-            time_point_sec date;
-            uint32_t data;
-            bool tradeable;
-            bool currency;
-            uint64_t primary_key() const { return symbol.raw(); }
-            uint64_t by_contract_key() const { return contract.value; }
-        };
+// TABLE tokens (registered currency) -----------
+// scope: contract
+TABLE reg_token_table {
+    symbol_code symbol;
+    vector<uint64_t> groups;       // this token may belong to a group of tokens
+    uint8_t precision;
+    name contract;
+    name admin;
+    string title;
+    string website;
+    string brief;
+    string banner;
+    string icon;
+    string iconlg;
+    string pcontact;
+    string gcontact;
+    time_point_sec date;
+    uint32_t data;
+    bool tradeable;
+    bool currency;
+    uint64_t primary_key() const { return symbol.raw(); }
+    uint64_t by_contract_key() const { return contract.value; }
+};
 
-        typedef eosio::multi_index< "tokens"_n, reg_token_table,
-            indexed_by<"contract"_n, const_mem_fun<reg_token_table, uint64_t, &reg_token_table::by_contract_key>>
-        > tokens;
-        // ------------------------------------
+typedef eosio::multi_index< "tokens"_n, reg_token_table,
+    indexed_by<"contract"_n, const_mem_fun<reg_token_table, uint64_t, &reg_token_table::by_contract_key>>
+> tokens;
+// ------------------------------------

--- a/include/vapaee/dex/tables/userorders.hpp
+++ b/include/vapaee/dex/tables/userorders.hpp
@@ -1,12 +1,11 @@
 #include "./_aux.hpp"
 
-        // TABLE userorders -----------
-        // scope: owner
-        TABLE userorders_table {
-            uint64_t market;
-            string table;
-            vector<uint64_t> ids;
-            uint64_t primary_key() const { return market; }
-        };
-        typedef eosio::multi_index< "userorders"_n, userorders_table > userorders;
-        // ------------------------------------
+
+// scope: owner
+TABLE userorders_table {
+    uint64_t market;
+    string table;
+    vector<uint64_t> ids;
+    uint64_t primary_key() const { return market; }
+};
+typedef eosio::multi_index<"userorders"_n, userorders_table > userorders;

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 addopts = -I=include
-log_cli = True 
+log_cli = False 
 log_cli_level = INFO
 log_format = %(asctime)s %(levelname)s %(message)s
 log_date_format = %M:%S

--- a/tests/telosbookdex/ballots/test_setcurrency.py
+++ b/tests/telosbookdex/ballots/test_setcurrency.py
@@ -74,7 +74,7 @@ def test_ballot_on_setcurrency_yes_currency(telosdecide, telosbookdex):
     sym, prec, token_acc, token_acc_id = telosbookdex.init_test_token()
 
     # has to previously be a currency
-    ec, _ = telosbookdex.set_currency(sym, True, 0)
+    ec, _ = telosbookdex.set_currency(telosbookdex.contract_name, sym, True, 0)
     assert ec == 0
 
     token_groups = telosbookdex.get_token_groups()
@@ -114,7 +114,7 @@ def test_ballot_on_setcurrency_no_currency(telosdecide, telosbookdex):
     sym, prec, token_acc, token_acc_id = telosbookdex.init_test_token()
 
     # has to previously be a currency
-    ec, _ = telosbookdex.set_currency(sym, True, 0)
+    ec, _ = telosbookdex.set_currency(telosbookdex.contract_name, sym, True, 0)
     assert ec == 0
 
     token_groups = telosbookdex.get_token_groups()

--- a/tests/telosbookdex/constants.py
+++ b/tests/telosbookdex/constants.py
@@ -12,22 +12,24 @@ import pytest
 
 from pytest_eosiocdt import (
     collect_stdout,
+    string_to_sym_code,
     name_to_string,
     random_string,
     random_local_url,
     random_token_symbol,
     Symbol,
-    Asset
+    Asset,
+    Name
 )
 from pytest_eosiocdt.telos import init_telos_token, telos_token, vote_token
 from pytest_eosiocdt.contract import SmartContract
 
 
-def get_market_scope(
+def get_market_index(
     sym_a: str,
     sym_b: str
-):
-    return f'{sym_a.lower()}.{sym_b.lower()}'[:12]
+) -> int:
+    return (string_to_sym_code(sym_a) << 64) | string_to_sym_code(sym_b)
 
 
 _did_init = False
@@ -298,12 +300,11 @@ class TelosBookDEX(SmartContract):
         sym_a: str,
         sym_b: str
     ):
-        market_scope = get_market_scope(sym_a, sym_b)
         markets = self.get_table(self.contract_name, 'markets')
-
         return next((
             market for market in markets
-            if market['table'] == market_scope),
+            if market['commodity'] == sym_a and
+            market['currency'] == sym_b),
             None
         )
 
@@ -312,8 +313,8 @@ class TelosBookDEX(SmartContract):
         symbol_a: str,
         symbol_b: str
     ):
-        buy_market = self.get_market(symbol_a.lower(), symbol_b.lower())
-        sell_market = self.get_market(symbol_b.lower(), symbol_a.lower())
+        buy_market = self.get_market(symbol_a, symbol_b)
+        sell_market = self.get_market(symbol_b, symbol_a)
 
         if (buy_market is None) or (sell_market is None):
             raise ValueError('market not found')
@@ -352,7 +353,7 @@ class TelosBookDEX(SmartContract):
         )
 
     def get_history(self, sym_a: str, sym_b: str):
-        market = self.get_market(sym_a.lower(), sym_b.lower())
+        market = self.get_market(sym_a, sym_b)
         assert market is not None
 
         market_id = name_to_string(market['id'])

--- a/tests/telosbookdex/constants.py
+++ b/tests/telosbookdex/constants.py
@@ -308,6 +308,14 @@ class TelosBookDEX(SmartContract):
             None
         )
 
+    def get_market_by_id(self, _id: int):
+        markets = self.get_table(self.contract_name, 'markets')
+        return next((
+            market for market in markets
+            if market['id'] == _id),
+            None
+        )
+
     def get_order_book(
         self,
         symbol_a: str,

--- a/tests/telosbookdex/test_history.py
+++ b/tests/telosbookdex/test_history.py
@@ -8,7 +8,7 @@ from pytest_eosiocdt import (
     name_to_string
 )
 
-from .constants import telosbookdex, get_market_scope
+from .constants import telosbookdex
 
 
 def test_order_check_history(telosbookdex):
@@ -22,7 +22,6 @@ def test_order_check_history(telosbookdex):
         precision=8
     )
     
-
     # generate needed eosio asset strings
     amount = 300
     price = 1000
@@ -101,8 +100,7 @@ def test_order_check_history(telosbookdex):
 
     # events logs individual events of all kinds, not only transactions
     # global scope
-    event_params = '|'.join([
-        get_market_scope(symbol, 'TLOS'),
+    event_params = '|' + '|'.join([
         buyer,
         seller,
         str_asset_amount,

--- a/tests/telosbookdex/test_history.py
+++ b/tests/telosbookdex/test_history.py
@@ -98,9 +98,13 @@ def test_order_check_history(telosbookdex):
     assert name_to_string(hall_trade['market']) == market_id
     assert hall_trade['date'] == trade['date']
 
+    market = telosbookdex.get_market_by_id(hall_trade['market'])
+    assert market
+
     # events logs individual events of all kinds, not only transactions
     # global scope
-    event_params = '|' + '|'.join([
+    event_params = '|'.join([
+        f'{market["currency"]}/{market["commodity"]}',
         buyer,
         seller,
         str_asset_amount,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+import logging
+
+from pytest_eosiocdt import (
+    eosio_testnet,
+    random_eosio_name,
+    random_token_symbol,
+    collect_stdout,
+    string_to_sym_code,
+    Name
+)
+
+from .telosbookdex.constants import get_market_index
+
+
+def test_sym_code_parsing(eosio_testnet):
+    sym = random_token_symbol()
+
+    ec, out = eosio_testnet.push_action(
+        'testcontract',
+        'rawsymcode',
+        [sym],
+        'eosio@active'
+    )
+    assert ec == 0
+
+    correct = int(collect_stdout(out))
+    actual = string_to_sym_code(sym)
+    logging.info(
+        f'\ncorrect: {correct}'
+        f'\nactual:  {actual}')
+
+    assert correct == actual 
+
+
+def test_name_parsing(eosio_testnet):
+    name = random_eosio_name()
+
+    ec, out = eosio_testnet.push_action(
+        'testcontract',
+        'rawname',
+        [name],
+        'eosio@active'
+    )
+    assert ec == 0
+
+    correct = int(collect_stdout(out))
+    actual = Name(name).value
+    logging.info(
+        f'\ncorrect: {correct}'
+        f'\nactual:  {actual}')
+
+    assert correct == actual 
+
+
+def test_symbols_get_index(eosio_testnet):
+    a, b = (random_token_symbol(), random_token_symbol())
+
+    ec, out = eosio_testnet.push_action(
+        'testcontract',
+        'getindex',
+        [a, b],
+        'eosio@active'
+    )
+    assert ec == 0
+
+    correct = int(collect_stdout(out))
+    actual = get_market_index(a, b)
+    logging.info(
+        f'\ncorrect: {correct}'
+        f'\nactual:  {actual}')
+
+    assert  correct == actual 
+

--- a/tests/testcontract/__init__.py
+++ b/tests/testcontract/__init__.py
@@ -1,0 +1,1 @@
+#!/usr/bin/env python3

--- a/tests/testcontract/test_utils.py
+++ b/tests/testcontract/test_utils.py
@@ -11,7 +11,7 @@ from pytest_eosiocdt import (
     Name
 )
 
-from .telosbookdex.constants import get_market_index
+from ..telosbookdex.constants import get_market_index
 
 
 def test_sym_code_parsing(eosio_testnet):


### PR DESCRIPTION
Change main indexing mechanic from using `table` field in table, formed using commodity and currency symbol codes joined by a dot, to using `uint128_t` secondary indexes.

```C++
uint128_t symbols_get_index(symbol_code A, symbol_code B) {
    return ((uint128_t)A.raw() << 64) | (uint128_t)B.raw();
}
```